### PR TITLE
Timestamp changed to ISO8601

### DIFF
--- a/server/src/main/resources/log4j.properties
+++ b/server/src/main/resources/log4j.properties
@@ -22,4 +22,4 @@ log4j.appender.A1=org.apache.log4j.ConsoleAppender
 
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+log4j.appender.A1.layout.ConversionPattern=[%d{ISO8601}] [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
https://tracker.mender.io/browse/MC-567

Currently it's quite tricky to investigate something when conductor makes relative timestamps in ms from container started. To make operations easier it would be better to have standard timestamp with date and time in it.